### PR TITLE
Features/state per module

### DIFF
--- a/src/_partystreusel/fabricator/layouts/includes/f-item-state.html
+++ b/src/_partystreusel/fabricator/layouts/includes/f-item-state.html
@@ -1,0 +1,5 @@
+{{#if data.inProgress}}
+  <div class="f-item-state" data-f-toggle-control="inProgress">
+    <span class="state in-progress">In Progress</span>
+  </div>
+{{/if}}

--- a/src/_partystreusel/fabricator/layouts/includes/f-item.html
+++ b/src/_partystreusel/fabricator/layouts/includes/f-item.html
@@ -1,22 +1,23 @@
 <div class="f-item-group" id="{{@key}}">
 
 {{#if items}}
-	<div class="f-item-heading-group">
-		<h2 class="f-item-heading" data-f-toggle="labels">{{name}}</h2>
-	</div>
-	{{#each items}}
-		<div class="f-item-group" id="{{@key}}">
-			<div class="f-item-heading-group" data-f-toggle="labels">
-				<h3 class="f-item-heading">{{name}}</h3>
-				{{> f-item-controls}}
-			</div>{{> f-item-content this}}
-		</div>
-	{{/each}}
+  <div class="f-item-heading-group">
+    <h2 class="f-item-heading" data-f-toggle="labels">{{name}}</h2>
+  </div>
+  {{#each items}}
+    <div class="f-item-group" id="{{@key}}">
+      <div class="f-item-heading-group" data-f-toggle="labels">
+        <h3 class="f-item-heading">{{name}}</h3>
+        {{> f-item-controls}}
+        {{> f-item-state}}
+      </div>{{> f-item-content this}}
+    </div>
+  {{/each}}
 {{else}}
-	<div class="f-item-heading-group" data-f-toggle="labels">
-		<h2 class="f-item-heading">{{name}}</h2>
-		{{> f-item-controls}}
-	</div>{{> f-item-content this}}
+  <div class="f-item-heading-group" data-f-toggle="labels">
+    <h2 class="f-item-heading">{{name}}</h2>
+    {{> f-item-controls}}
+  </div>{{> f-item-content this}}
 {{/if}}
 
 </div>

--- a/src/_partystreusel/fabricator/styles/partials/_item.scss
+++ b/src/_partystreusel/fabricator/styles/partials/_item.scss
@@ -109,3 +109,12 @@
     font-weight: bold;
   }
 }
+
+.f-item-state {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background-color: #f08a24;
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
Hey @kuschti 

I managed to show an in progress state for each module but wasn't able to show it on the navigation. If we want this, we have to tweak the `fabricator-assemble` package. This is where the magic happens.

The package handles also the objects, which are used in the fabricator views. This is also the reason, why I had to get the inProgress property from the data object. If we want this in the root, we also have to customise the `fabricator-assemble` package.

Another problem is that we sometimes have multiple variations of a module, right? The navigation only renders one navigation point for each module and not each variation. So it's kinda hard do get the state for a whole module with multiple variations, when not every variation is production ready.

You can see what I mean, when you add `{{log this}}` in the loop of every menu entry in the file `f-menu.html`.

---

To use the new flag the data object of each module could look like this:

``` yaml
---
inProgress: true
notes: |
  This is not a module to use it, only for styleguide presentation.
---
```