### PR TITLE
Fix initialization of JS classes for IE10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "transform-proto-to-assign",
+    ["transform-es2015-classes", {
+      "loose": true
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "devDependencies": {
     "babel-core": "^6.23.1",
     "babel-loader": "^6.3.2",
+    "babel-plugin-transform-es2015-classes": "^6.23.0",
+    "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "browser-sync": "^2.18.8",

--- a/src/application.js
+++ b/src/application.js
@@ -10,8 +10,8 @@ $(() => {
   $('html').removeClass('no-js');
   const Streusel = window.Streusel || {};
 
-  Streusel.Accordion = Accordion.init();
   Streusel.Topbar = Topbar.init();
+  Streusel.Accordion = Accordion.init();
   Streusel.Tab = Tab.init();
   Streusel.Dropdown = Dropdown.init();
   Streusel.Slider = Slider.init();

--- a/src/materials/molecules/topbar/topbar.js
+++ b/src/materials/molecules/topbar/topbar.js
@@ -4,13 +4,12 @@ import Base from '../../../_config/base';
 class Topbar extends Base {
   constructor(el) {
     super(el);
-    this.el = $(el);
     $(el).find('.topbar__mobile-menu').on('click', this.toggle.bind(this));
     $(el).find('.topbar__item').on('click', this.toggleItem);
   }
 
   toggle() {
-    this.el.toggleClass('topbar--open');
+    this.$el.toggleClass('topbar--open');
   }
 
   static toggleItem(e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,6 +372,15 @@ babel-helper-define-map@^6.22.0:
     babel-types "^6.22.0"
     lodash "^4.2.0"
 
+babel-helper-define-map@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz#1444f960c9691d69a2ced6a205315f8fd00804e7"
+  dependencies:
+    babel-helper-function-name "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
+    lodash "^4.2.0"
+
 babel-helper-explode-assignable-expression@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz#c97bf76eed3e0bae4048121f2b9dae1a4e7d0478"
@@ -399,6 +408,16 @@ babel-helper-function-name@^6.22.0:
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
 
+babel-helper-function-name@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz#25742d67175c8903dbe4b6cb9d9e1fcb8dcf23a6"
+  dependencies:
+    babel-helper-get-function-arity "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
+
 babel-helper-get-function-arity@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz#0beb464ad69dc7347410ac6ade9f03a50634f5ce"
@@ -419,6 +438,13 @@ babel-helper-optimise-call-expression@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-optimise-call-expression@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz#f3ee7eed355b4282138b33d02b78369e470622f5"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
 
 babel-helper-regex@^6.22.0:
   version "6.22.0"
@@ -448,6 +474,17 @@ babel-helper-replace-supers@^6.22.0:
     babel-template "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-replace-supers@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz#eeaf8ad9b58ec4337ca94223bacdca1f8d9b4bfd"
+  dependencies:
+    babel-helper-optimise-call-expression "^6.23.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
 babel-helpers@^6.23.0:
   version "6.23.0"
@@ -579,6 +616,20 @@ babel-plugin-transform-es2015-classes@^6.22.0:
     babel-template "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz#49b53f326202a2fd1b3bbaa5e2edd8a4f78643c1"
+  dependencies:
+    babel-helper-define-map "^6.23.0"
+    babel-helper-function-name "^6.23.0"
+    babel-helper-optimise-call-expression "^6.23.0"
+    babel-helper-replace-supers "^6.23.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.23.0"
+    babel-traverse "^6.23.0"
+    babel-types "^6.23.0"
 
 babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.22.0"
@@ -726,6 +777,13 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-proto-to-assign@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.23.0.tgz#1c24951598793fc6a1d18118a11de1c36376fe2e"
+  dependencies:
+    babel-runtime "^6.22.0"
+    lodash "^4.2.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
Hi @kuschti 

This should resolve all issues with IE10. There were some issues about the whole inheritance and super calls. If you're interested in it check out the following links:

* https://github.com/babel/babel/issues/3041
* https://github.com/babel/babel/pull/3527
* https://github.com/babel/babelify/issues/133

Some babel plugins solved the issue. See in .babelrc what kind of plugins were needed.

The `application.js` is now even 4KB smaller :wink: